### PR TITLE
♻️ Refactor: access 토큰 저장 방식 변경

### DIFF
--- a/src/app/login/_component/policies.tsx
+++ b/src/app/login/_component/policies.tsx
@@ -2,8 +2,8 @@ import axios from "axios";
 import Link from "next/link";
 
 export default function Policies() {
-  function saveTokenToCookie(accessToken: string, refreshToken: string) {
-    document.cookie = `accessToken=${accessToken}; path=/;`;
+  function saveTokens(accessToken: string, refreshToken: string) {
+    localStorage.setItem("accessToken", accessToken);
     document.cookie = `refreshToken=${refreshToken}; path=/; `;
   }
 
@@ -15,7 +15,7 @@ export default function Policies() {
 
       const { accessToken, refreshToken } = response.data.result;
       if (accessToken && refreshToken) {
-        saveTokenToCookie(accessToken, refreshToken);
+        saveTokens(accessToken, refreshToken);
       }
 
       window.location.href = "/";

--- a/src/app/registration-form/page.tsx
+++ b/src/app/registration-form/page.tsx
@@ -4,9 +4,9 @@ import axios from "axios";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 
-function saveTokenToCookie(accessToken: string, refreshToken: string) {
+function saveTokens(accessToken: string, refreshToken: string) {
   // 현 단계에서 httpOnly, Secure 넣을 경우 쿠키에서 확인 불가능해 제외
-  document.cookie = `accessToken=${accessToken}; path=/; `;
+  localStorage.setItem("accessToken", accessToken);
   document.cookie = `refreshToken=${refreshToken}; path=/; `;
 }
 
@@ -36,7 +36,7 @@ export default function RegistrationForm() {
     let refreshToken = queryParams.get("refresh");
 
     if (accessToken && refreshToken) {
-      saveTokenToCookie(accessToken, refreshToken);
+      saveTokens(accessToken, refreshToken);
 
       checkRegistration(accessToken)
         .then((data) => {


### PR DESCRIPTION
## 1. 액세스 토큰 저장 방식 변경
- 쿠키에 저장되던 액세스 토큰을 로컬스토리지에 저장되도록 변경했습니다.
- 리프레시 토큰은 변경 없이 쿠키에 계속 저장됩니다. 