### PR TITLE
✨ Feat: Tabs 컴포넌트 swiper 적용 및 Card 컴포넌트 제작

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "pnpm": "^9.14.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "swiper": "^11.1.15",
     "tailwind-merge": "^2.5.4",
     "uuid": "^11.0.3",
     "zustand": "^5.0.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      swiper:
+        specifier: ^11.1.15
+        version: 11.1.15
       tailwind-merge:
         specifier: ^2.5.4
         version: 2.5.5
@@ -3945,6 +3948,10 @@ packages:
     resolution: {integrity: sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  swiper@11.1.15:
+    resolution: {integrity: sha512-IzWeU34WwC7gbhjKsjkImTuCRf+lRbO6cnxMGs88iVNKDwV+xQpBCJxZ4bNH6gSrIbbyVJ1kuGzo3JTtz//CBw==}
+    engines: {node: '>= 4.7.0'}
 
   tailwind-merge@2.5.5:
     resolution: {integrity: sha512-0LXunzzAZzo0tEPxV3I297ffKZPlKDrjj7NXphC8V5ak9yHC5zRmxnOe2m/Rd/7ivsOMJe3JZ2JVocoDdQTRBA==}
@@ -8729,6 +8736,8 @@ snapshots:
       css-what: 6.1.0
       csso: 5.0.5
       picocolors: 1.1.1
+
+  swiper@11.1.15: {}
 
   tailwind-merge@2.5.5: {}
 

--- a/src/app/(main)/_component/performance-list.tsx
+++ b/src/app/(main)/_component/performance-list.tsx
@@ -1,0 +1,85 @@
+import Card from "@/components/card";
+import Chip from "@/components/commons/chip";
+import SectionLayout from "@/components/section-layout";
+import Tabs from "./tabs";
+
+const TAB_CATEGORY = [
+  { id: 0, name: "전체" },
+  { id: 1, name: "공연" },
+  { id: 2, name: "뮤지컬" },
+  { id: 3, name: "대중무용" },
+  { id: 4, name: "서커스/마술" },
+  { id: 5, name: "무용" },
+  { id: 6, name: "복합" },
+];
+
+export default function PerformanceList() {
+  return (
+    <>
+      <Tabs categories={TAB_CATEGORY} gap={12} className="h-11 py-[6px]" />
+      <SectionLayout className="flex flex-col py-4 gap-3">
+        {PERF_MOCKUP_DATA.map((data) => (
+          <Card key={data.id} className="w-full">
+            <Card.Image src={data.image.src} alt={data.image.alt} width="w-[88px]" height="h-[88px]" />
+            <Card.Content>
+              <Card.Category>
+                <Chip label={data.category.label} state="hashTag" />
+              </Card.Category>
+              <Card.Title>{data.title}</Card.Title>
+              <Card.Info iconSrc={data.info.iconSrc} info={data.info.text} />
+            </Card.Content>
+          </Card>
+        ))}
+      </SectionLayout>
+    </>
+  );
+}
+
+// api로 대체하여 삭제예정
+const PERF_MOCKUP_DATA = [
+  {
+    id: 1,
+    image: {
+      src: "/img/logo-image.png",
+      alt: "눈꽃",
+    },
+    category: {
+      label: "서커스/마술",
+    },
+    title: "매직쇼 더 라이브 [춘천]",
+    info: {
+      iconSrc: "/img/logo-image.png",
+      text: "춘천교육문화관 공연장",
+    },
+  },
+  {
+    id: 2,
+    image: {
+      src: "/img/logo-image.png",
+      alt: "눈꽃",
+    },
+    category: {
+      label: "서커스/마술",
+    },
+    title: "매직쇼 더 라이브 [춘천]",
+    info: {
+      iconSrc: "/img/logo-image.png",
+      text: "춘천교육문화관 공연장",
+    },
+  },
+  {
+    id: 3,
+    image: {
+      src: "/img/logo-image.png",
+      alt: "눈꽃",
+    },
+    category: {
+      label: "서커스/마술",
+    },
+    title: "매직쇼 더 라이브 [춘천]",
+    info: {
+      iconSrc: "/img/logo-image.png",
+      text: "춘천교육문화관 공연장",
+    },
+  },
+];

--- a/src/app/(main)/_component/tabs/index.tsx
+++ b/src/app/(main)/_component/tabs/index.tsx
@@ -1,15 +1,50 @@
-import Chip from "@/components/commons/chip";
-import SectionLayout from "@/components/section-layout";
+"use client";
 
-export default function Tabs() {
+import "swiper/css";
+import { Swiper, SwiperSlide } from "swiper/react";
+
+import Chip from "@/components/commons/chip";
+import cn from "@/lib/tailwind-cn";
+import { useState } from "react";
+
+type Category = {
+  id: number;
+  name: string;
+};
+
+type TabsProps = {
+  categories: Category[];
+  gap?: number;
+  onTabClick?: (category: Category) => void;
+  className?: string;
+};
+
+export default function Tabs({ categories, gap = 12, onTabClick, className = "" }: TabsProps) {
+  const [selectedTabId, setSelectedTabId] = useState<number>(categories.length > 0 ? categories[0].id : 0);
+
+  const handleChipClick = (category: Category) => {
+    setSelectedTabId(category.id);
+    onTabClick?.(category);
+  };
+
   return (
-    <SectionLayout className="flex h-11 gap-3 py-[6px]">
-      <Chip label="전체" />
-      <Chip label="연극" />
-      <Chip label="무용" />
-      <Chip label="대중무용" />
-      <Chip label="서커스/마술" />
-      <Chip label="복합" />
-    </SectionLayout>
+    <Swiper
+      slidesPerView="auto"
+      freeMode={true}
+      spaceBetween={gap}
+      slidesOffsetBefore={16}
+      slidesOffsetAfter={16}
+      className={cn("w-full cursor-pointer", className)}
+    >
+      {categories.map((category) => (
+        <SwiperSlide key={category.id} className="!w-auto">
+          <Chip
+            label={category.name}
+            state={selectedTabId === category.id ? "selected" : "default"}
+            onClick={() => handleChipClick(category)}
+          />
+        </SwiperSlide>
+      ))}
+    </Swiper>
   );
 }

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,12 +1,21 @@
 import AdBanner from "./_component/banner";
 import Tabs from "./_component/tabs";
 
+const TAB_CATEGORY = [
+  { id: 0, name: "전체" },
+  { id: 1, name: "공연" },
+  { id: 2, name: "뮤지컬" },
+  { id: 3, name: "대중무용" },
+  { id: 4, name: "서커스/마술" },
+  { id: 5, name: "무용" },
+  { id: 6, name: "복합" },
+];
+
 export default function HomePage() {
   return (
     <>
       <AdBanner />
-      <Tabs />
-      <p>github actions test comment</p>
+      <Tabs categories={TAB_CATEGORY} gap={12} className="h-11 py-[6px]" />
     </>
   );
 }

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,21 +1,11 @@
 import AdBanner from "./_component/banner";
-import Tabs from "./_component/tabs";
-
-const TAB_CATEGORY = [
-  { id: 0, name: "전체" },
-  { id: 1, name: "공연" },
-  { id: 2, name: "뮤지컬" },
-  { id: 3, name: "대중무용" },
-  { id: 4, name: "서커스/마술" },
-  { id: 5, name: "무용" },
-  { id: 6, name: "복합" },
-];
+import PerformanceList from "./_component/performance-list";
 
 export default function HomePage() {
   return (
     <>
       <AdBanner />
-      <Tabs categories={TAB_CATEGORY} gap={12} className="h-11 py-[6px]" />
+      <PerformanceList />
     </>
   );
 }

--- a/src/components/card/card.stories.tsx
+++ b/src/components/card/card.stories.tsx
@@ -1,0 +1,160 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { ReactNode } from "react";
+import Chip from "../commons/chip";
+import Card from "./index";
+
+type CardStoryArgs = {
+  className?: string;
+  imageSrc: string;
+  imageAlt: string;
+  ImageWidth: string;
+  ImageHeight: string;
+  title: string;
+  category: string;
+  info: string;
+  iconSrc?: string;
+  children: ReactNode;
+};
+
+const meta: Meta<CardStoryArgs> = {
+  title: "Components/Card",
+  component: Card,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+
+  argTypes: {
+    className: {
+      description: "Card의 추가 스타일을 지정",
+      control: { type: "text" },
+    },
+    children: {
+      description: "Card 내부의 컨텐츠를 정의",
+    },
+    imageSrc: {
+      description: "Card 왼쪽 메인 이미지의 경로",
+      control: { type: "text" },
+    },
+    imageAlt: {
+      description: "이미지의 대체 텍스트",
+      control: { type: "text" },
+    },
+    ImageWidth: {
+      description: "이미지 width 값. w-[00px] 형태로 사용",
+      control: { type: "text" },
+    },
+    ImageHeight: {
+      description: "이미지의 height 값. h-[00px] 형태로 사용",
+      control: { type: "text" },
+    },
+    title: {
+      description: "Card의 제목 정의",
+      control: { type: "text" },
+    },
+    category: {
+      description: "카테고리 정보 제공",
+      control: { type: "text" },
+    },
+    info: {
+      description: "추가 정보 표시",
+      control: { type: "text" },
+    },
+    iconSrc: {
+      description: "정보 아이콘 이미지 경로",
+      control: { type: "text" },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<CardStoryArgs>;
+
+export const Default: Story = {
+  render: (args) => (
+    <div className="w-[430px]">
+      <Card className={args.className}>
+        <Card.Image src={args.imageSrc} alt={args.imageAlt} width={args.ImageWidth} height={args.ImageHeight} />
+        <Card.Content>
+          <Card.Category>
+            <Chip label={args.category} state="hashTag" />
+          </Card.Category>
+          <Card.Title>{args.title}</Card.Title>
+          <Card.Info iconSrc={args.iconSrc} info={args.info} />
+        </Card.Content>
+      </Card>
+    </div>
+  ),
+  args: {
+    className: "w-full",
+    imageSrc: "/img/logo-image.png",
+    imageAlt: "눈꽃 이미지",
+    ImageWidth: "w-[88px]",
+    ImageHeight: "h-[88px]",
+    category: "서커스/마술",
+    title: "매직쇼 더 라이브 [춘천]",
+    info: "춘천교육문화관 공연장",
+    iconSrc: "/img/logo-image.png",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: `
+- 이 스토리는 기본 Card 컴포넌트를 보여줍니다.
+- Card 컴포넌트는 재사용 가능한 카드 UI를 생성하는 데 사용되며, Compound Pattern으로 구성되어 있습니다.
+- 사용 예제:
+\`\`\`
+<Card className="w-full">
+  <Card.Image src="/img/sample.png" alt="이미지 설명" width="w-[88px]" height="h-[88px]" />
+  <Card.Content>
+    <Card.Category>
+      <Chip label="카테고리" state="hashTag" />
+    </Card.Category>
+    <Card.Title>카드 제목</Card.Title>
+    <Card.Info iconSrc="/img/icon.png" info="추가 정보" />
+  </Card.Content>
+</Card>
+\`\`\`
+        `,
+      },
+    },
+  },
+};
+
+export const WithLongText: Story = {
+  render: (args) => (
+    <div className="w-[430px]">
+      <Card className={args.className}>
+        <Card.Image src={args.imageSrc} alt={args.imageAlt} width={args.ImageWidth} height={args.ImageHeight} />
+        <Card.Content>
+          <Card.Category>
+            <Chip label={args.category} state="hashTag" />
+          </Card.Category>
+          <Card.Title>{args.title}</Card.Title>
+          <Card.Info iconSrc={args.iconSrc} info={args.info} />
+        </Card.Content>
+      </Card>
+    </div>
+  ),
+  args: {
+    className: "w-full",
+    imageSrc: "/img/logo-image.png",
+    imageAlt: "긴 텍스트 이미지",
+    ImageWidth: "w-[88px]",
+    ImageHeight: "h-[88px]",
+    category: "긴 텍스트 카테고리 hashtag",
+    title: "매우 긴 제목이 들어가도 문제가 없는 카드 타이틀",
+    info: "긴 텍스트가 입력되면 ...으로 문장이 끝납니다. 이를 통해 일관된 디자인을 얻습니다.",
+    iconSrc: "/img/logo-image.png",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: `
+  - 이 스토리는 title과 info의 내용이 길어질 때의 Card 컴포넌트를 테스트합니다.
+        `,
+      },
+    },
+  },
+};

--- a/src/components/card/index.tsx
+++ b/src/components/card/index.tsx
@@ -1,0 +1,89 @@
+import cn from "@/lib/tailwind-cn";
+import Image from "next/image";
+import { ReactNode } from "react";
+
+type CardProps = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+export default function Card({ children, className }: CardProps) {
+  return <div className={cn("flex p-4 border border-gray-200 rounded-lg", className)}>{children}</div>;
+}
+
+type CardImageProps = {
+  src: string;
+  alt: string;
+  width: string;
+  height: string;
+  className?: string;
+};
+
+function CardImage({ src, alt, width, height, className }: CardImageProps) {
+  return (
+    <div
+      className={cn(
+        `flex-shrink-0 relative ${width} ${height} mr-4 bg-white border border-gray-200 rounded-lg overflow-hidden`,
+        className,
+      )}
+    >
+      <Image src={src} alt={alt} fill className="object-contain" />
+    </div>
+  );
+}
+
+type CardContentProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+function CardContent({ children, className }: CardContentProps) {
+  return <div className={cn("flex flex-col justify-center min-w-0", className)}>{children}</div>;
+}
+
+type CardCategoryProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+function CardCategory({ children, className }: CardCategoryProps) {
+  return <div className={cn("mb-2", className)}>{children}</div>;
+}
+
+type CardTitleProps = {
+  children: string;
+  className?: string;
+};
+
+function CardTitle({ children, className }: CardTitleProps) {
+  return (
+    <h3 className={cn("text-sm font-semibold whitespace-nowrap overflow-hidden text-ellipsis", className)}>
+      {children}
+    </h3>
+  );
+}
+
+type CardInfoProps = {
+  iconSrc?: string;
+  info: string;
+  className?: string;
+};
+
+function CardInfo({ iconSrc, info, className }: CardInfoProps) {
+  return (
+    <div className={cn("flex items-center mt-1 text-xs text-gray-500", className)}>
+      {iconSrc && (
+        <div className="flex-shrink-0 w-4 h-4 mr-2">
+          <Image src={iconSrc} alt="icon" width={16} height={16} className="w-full h-full object-contain" />
+        </div>
+      )}
+      <span className="inline-block whitespace-nowrap overflow-hidden text-ellipsis">{info}</span>
+    </div>
+  );
+}
+
+Card.Image = CardImage;
+Card.Content = CardContent;
+Card.Category = CardCategory;
+Card.Title = CardTitle;
+Card.Info = CardInfo;

--- a/src/components/commons/chip/index.tsx
+++ b/src/components/commons/chip/index.tsx
@@ -18,7 +18,7 @@ const chipVariants = cva(
     compoundVariants: [
       {
         state: "hashTag",
-        className: "font-normal text-xs cursor-default", // 해시태그 상태에서 hover와 pointer 제거
+        className: "h-6 px-2 py-0 font-normal text-xs cursor-default", // 해시태그 상태에서 hover와 pointer 제거
       },
     ],
     defaultVariants: {


### PR DESCRIPTION
## 1. Tabs 컴포넌트에 swipe 기능을 추가하였습니다.
- 초기 왼쪽 여백 설정 → swipe 작동 시 여백 없도록 css 작업

## 2. Card 컴포넌트 제작
- compound pattern을 사용했습니다.
- Storybook에 Card UI 테스트를 추가하였습니다.
- 사용법은 Storybook을 참고해주세요. 자세하게 작성해두었습니다.

## ※ 현재 메인 페이지 gif
<img src="https://github.com/user-attachments/assets/dd71ceba-5843-4de2-bada-192a999955aa" width="450" height="650" />

## 3. 그 외
- Chip 컴포넌트 중 hashtag인 경우 height를 지정하였습니다.
- 일관된 pnpm 패키지 사용을 위해 git clone을 사용한 이후 pnpm install --frozen-lockfile을 통해 pnpm 종속성을 설치합니다.
- 이를 통해 동일한 작업환경을 유지할 수 있어서 해당 명령어를 사용해보면 좋을 것 같아요!
- 오늘 이후 작업은 메인 페이지-공연 상세페이지 api 연동, header 동적 컴포넌트를 우선적으로 할 예정입니다.
- 변경된 navigation bar 디자인은 추후 반영 예정입니다.
