### PR TITLE
✨ Feat: 검색 페이지 제작

### DIFF
--- a/src/app/(main)/search/page.tsx
+++ b/src/app/(main)/search/page.tsx
@@ -1,3 +1,10 @@
+import SearchLayout from "@/components/layout/search-layout";
+import SearchPages from "@/components/search";
+
 export default function SearchPage() {
-  return <div>searchPage</div>;
+  return (
+    <SearchLayout>
+      <SearchPages />
+    </SearchLayout>
+  );
 }

--- a/src/components/layout/search-layout/index.tsx
+++ b/src/components/layout/search-layout/index.tsx
@@ -1,0 +1,13 @@
+import NavigationBar from "@/components/navigation-bar";
+import SearchBar from "@/components/search-bar";
+import { PropsWithChildren } from "react";
+
+export default function SearchLayout({ children }: PropsWithChildren<{}>) {
+  return (
+    <div className="relative flex flex-col min-h-screen">
+      <SearchBar className="sticky top-0 w-full z-header" />
+      <main className="flex-1 overflow-y-auto hide-scrollbar mobile-smooth-touch-scrolling bg-white">{children}</main>
+      <NavigationBar className="sticky bottom-0 w-full z-navbar" />
+    </div>
+  );
+}

--- a/src/components/search-bar/index.tsx
+++ b/src/components/search-bar/index.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { ChangeEvent } from "react";
+import { useRouter } from "next/navigation";
+import cn from "@/lib/tailwind-cn";
+
+import ArrowBack from "@/assets/icons/arrow-back.svg";
+import CloseIcon from "@/assets/icons/cancel.svg";
+import { useSearchStore } from "@/stores/useSearchStore";
+import Icon from "@/components/commons/icon";
+
+export type SearchBarProps = {
+  className?: string;
+};
+
+export default function SearchBar(className: SearchBarProps) {
+  const router = useRouter();
+  const { searchQuery, setSearchQuery } = useSearchStore();
+
+  const handleGoBack = () => {
+    router.back();
+  };
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(e.target.value);
+  };
+
+  const handleClear = () => {
+    setSearchQuery("");
+  };
+
+  return (
+    <header className={cn("relative flex items-center justify-between w-full h-[48px] px-4 py-2 bg-white", className)}>
+      {/* 왼쪽: 뒤로가기 버튼 */}
+      <div className="flex items-center justify-start space-x-2">
+        <Icon onClick={handleGoBack} size={24} className="cursor-pointer">
+          <ArrowBack />
+        </Icon>
+      </div>
+
+      {/* 중앙: 검색창 */}
+      <div className="flex items-center justify-center w-[350px] h-9 bg-gray-50 rounded-full px-4">
+        <input
+          type="text"
+          value={searchQuery}
+          onChange={handleChange}
+          className="w-full h-full bg-transparent outline-none text-gray-700"
+        />
+        {searchQuery && (
+          <button onClick={handleClear} className="text-gray-400 hover:text-gray-600">
+            <Icon size={24}>
+              <CloseIcon />
+            </Icon>
+          </button>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useEffect } from "react";
+import { useSearchStore } from "@/stores/useSearchStore";
+import SearchRecommend from "./recommend";
+import SearchResult from "./result";
+
+export default function SearchPages() {
+  const { searchQuery, setSearchQuery } = useSearchStore();
+
+  // 검색어 초기화
+  useEffect(() => {
+    setSearchQuery("");
+  }, [setSearchQuery]);
+
+  return <>{searchQuery ? <SearchResult /> : <SearchRecommend />}</>;
+}

--- a/src/components/search/recommend/index.tsx
+++ b/src/components/search/recommend/index.tsx
@@ -1,0 +1,89 @@
+import { useSearchStore } from "@/stores/useSearchStore";
+
+type Recommendation = {
+  performId: string;
+  performName: string;
+  genreName: string;
+};
+
+export default function SearchRecommend() {
+  const { setSearchQuery } = useSearchStore();
+
+  // 추천 검색어 목록 API 호출
+
+  // 추천 검색어 클릭 시 검색창에 추천 검색어 입력
+  function handleClick(item: Recommendation) {
+    return () => {
+      setSearchQuery(item.performName);
+    };
+  }
+
+  return (
+    <div className="p-4">
+      <h2 className="font-semibold text-lg mb-4">추천 검색어</h2>
+      <ul>
+        {RECOMMEND_MOCKUP_DATA.map((item, index) => (
+          <li key={item.performId} className="text-base">
+            <div className="flex items-center gap-3 py-2 text-gray-600 cursor-pointer" onClick={handleClick(item)}>
+              <span>{index + 1}</span>
+              <span>{item.performName}</span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+const RECOMMEND_MOCKUP_DATA: Recommendation[] = [
+  {
+    performId: "PF255055",
+    performName: "원: 죄 [창원]",
+    genreName: "연극",
+  },
+  {
+    performId: "PF255289",
+    performName: "고래바위에서 기다려",
+    genreName: "연극",
+  },
+  {
+    performId: "PF255046",
+    performName: "마음 속 사거리 좌회전 [대구]",
+    genreName: "연극",
+  },
+  {
+    performId: "PF255478",
+    performName: "머더",
+    genreName: "연극",
+  },
+  {
+    performId: "PF255478",
+    performName: "머더",
+    genreName: "연극",
+  },
+  {
+    performId: "PF255029",
+    performName: "하나의 소리 여러 개의 이야기: 하마 [대전]",
+    genreName: "연극",
+  },
+  {
+    performId: "PF255448",
+    performName: "모삐-삐-삐-딕!",
+    genreName: "연극",
+  },
+  {
+    performId: "PF255448",
+    performName: "모삐-삐-삐-딕!",
+    genreName: "연극",
+  },
+  {
+    performId: "PF255081",
+    performName: "정원사와의 산책",
+    genreName: "연극",
+  },
+  {
+    performId: "PF255444",
+    performName: "대진대학교 연기예술학과, More Than Hamlet (모어 댄 햄릿)",
+    genreName: "연극",
+  },
+];

--- a/src/components/search/result/index.tsx
+++ b/src/components/search/result/index.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useSearchStore } from "@/stores/useSearchStore";
+import { SectionLayout } from "@/components/layout";
+import Card from "@/components/card";
+import Chip from "@/components/commons/chip";
+import Search from "@/assets/icons/search.svg";
+import Location from "@/assets/icons/location.svg";
+import Icon from "@/components/commons/icon";
+
+export default function SearchResult() {
+  const { searchQuery } = useSearchStore();
+
+  // searchQuery를 공연명으로 검색 결과 조회 API 호출
+
+  return (
+    <SectionLayout className="flex flex-col py-4 gap-3">
+      {RESULT_MOCKUP_DATA.length === 0 ? (
+        <div className="flex flex-col items-center justify-center h-screen bg-white">
+          <div className="mb-4">
+            <Icon size={24}>
+              <Search />
+            </Icon>
+          </div>
+          <p className="text-lg font-semibold text-red-500 mb-2">검색 결과가 없습니다!</p>
+          <p className="text-sm text-gray-600 text-center">
+            입력하신 키워드를 다시 확인하거나 다른 검색어를 입력해보세요.
+          </p>
+        </div>
+      ) : (
+        RESULT_MOCKUP_DATA.map((performance) => (
+          <Card key={performance.performId} className="w-full">
+            <Card.Image src={performance.poster} alt={performance.performName} width={"w-[88px]"} height={"h-[88px]"} />
+            <Card.Content>
+              <Card.Category>
+                <Chip label={performance.genreName} state="hashTag" />
+              </Card.Category>
+              <Card.Title>{performance.performName}</Card.Title>
+              <Card.Info info={performance.placeName} />
+            </Card.Content>
+          </Card>
+        ))
+      )}
+    </SectionLayout>
+  );
+}
+
+const RESULT_MOCKUP_DATA = [
+  {
+    performId: "PF253504",
+    performName: "초록마술사의 크리스마스 매직쇼 [부산]",
+    startDate: "2024.11.30",
+    endDate: "2024.12.25",
+    genreName: "서커스/마술",
+    performState: "공연중",
+    placeName: "초록마술극장",
+    openRun: false,
+    area: "부산광역시",
+    poster: "http://www.kopis.or.kr/upload/pfmPoster/PF_PF253504_241112_155450.jpg",
+    likeCount: 6,
+  },
+  {
+    performId: "PF254935",
+    performName: "신기한 마술사전 [인천 (앵콜) ]",
+    startDate: "2024.11.30",
+    endDate: "2025.03.30",
+    genreName: "서커스/마술",
+    performState: "공연중",
+    placeName: "루시드아트홀",
+    openRun: false,
+    area: "인천광역시",
+    poster: "http://www.kopis.or.kr/upload/pfmPoster/PF_PF254935_241202_095010.jpg",
+    likeCount: 4,
+  },
+  {
+    performId: "PF255447",
+    performName: "어린이 벌룬쇼, 상상풍선마술단 [창원]",
+    startDate: "2024.12.07",
+    endDate: "2025.01.26",
+    genreName: "서커스/마술",
+    performState: "공연중",
+    placeName: "창원 스타인웨이홀(상상플레이스, G.I.L. 아트홀)",
+    openRun: false,
+    area: "경상남도",
+    poster: "http://www.kopis.or.kr/upload/pfmPoster/PF_PF255447_241209_112913.png",
+    likeCount: 0,
+  },
+];

--- a/src/stores/useSearchStore.ts
+++ b/src/stores/useSearchStore.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+interface SearchState {
+  searchQuery: string;
+  setSearchQuery: (query: string) => void;
+}
+
+export const useSearchStore = create<SearchState>((set) => ({
+  searchQuery: "",
+  setSearchQuery: (query) => set({ searchQuery: query }),
+}));


### PR DESCRIPTION
## 📝 요약(Summary)
<h3>1. 검색 페이지용 search layout 제작</h3>
- 검색 페이지의 헤더는 기존 layout을 사용하기 어려워 유사한 형태의 search layout을 별도로 제작했습니다. main layout의 header 부분에 검색창을 만들었습니다.
<h3>2. 검색어 전역으로 관리</h3>
- 검색창이 header에 있는 search layout 구조상 입력값이 변했을 때 prop drilling이 발생할 수 있어 전역으로 관리했습니다.

<br/>

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br/>

## 📸스크린샷 (선택)
- 추천 검색어
![image](https://velog.velcdn.com/images/22gyoung/post/1715694a-aa06-4a87-86ed-75b79638b9c3/image.png)

- 검색 결과
![image](https://velog.velcdn.com/images/22gyoung/post/90938490-d79e-48c5-b9aa-5def2c73bc5e/image.png)

- 검색 결과 없음
![image](https://velog.velcdn.com/images/22gyoung/post/ced4fe95-38f4-4562-bae6-35a5845043b6/image.png)

<br/>

## 💬 공유사항 to 리뷰어
'/home'이 아닌 다른 경로에서 '/search'로 이동할 경우에도 이전 경로(예: feed, wishlist)의 아이콘이 활성화되지 않고 홈 아이콘이 활성화됩니다. 
useRef를 사용해 경로가 변경될 때마다 이전 경로와 현재 경로를 비교해 현재 경로가 '/search'일 경우에만 이전 경로를 return하는 방법을 써 봤는데 '/search'로 이동해도 현재 경로를 return해요. 
이거 해결해보고 싶어서 시간이 좀 걸렸는데 그냥 검색페이지도 홈인 걸로 간주할까요 ?
