### PR TITLE
🐛 Fix: 이미지 여러 장 업로드 시 이미지 보이지 않는 문제 해결

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { IntroText, LoginButton, Logo, Policies, Title } from "./_component";
+import { IntroText, LoginButton, Logo, Title } from "./_component";
 
 export default function LoginPage(): JSX.Element {
   // 카카오 SDK 초기화
@@ -28,7 +28,7 @@ export default function LoginPage(): JSX.Element {
       <Title />
       <IntroText />
       <LoginButton />
-      <Policies />
+      {/* <Policies /> */}
     </main>
   );
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { IntroText, LoginButton, Logo, Title } from "./_component";
+import { IntroText, LoginButton, Logo, Policies, Title } from "./_component";
 
 export default function LoginPage(): JSX.Element {
   // 카카오 SDK 초기화
@@ -28,7 +28,7 @@ export default function LoginPage(): JSX.Element {
       <Title />
       <IntroText />
       <LoginButton />
-      {/* <Policies /> */}
+      <Policies />
     </main>
   );
 }

--- a/src/components/feed/item/feed-image.tsx
+++ b/src/components/feed/item/feed-image.tsx
@@ -16,17 +16,12 @@ export default function FeedImage({ feedFiles }: ImageCarouselProps) {
             spaceBetween={10}
             slidesPerView={1}
             pagination={{ clickable: false }}
-            navigation={false}
             loop={false}
             modules={[Pagination]}
           >
             {feedFiles.map((file, index) => (
               <SwiperSlide key={file}>
-                <img
-                  src={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}${file}`}
-                  alt={`feed-image-${index}`}
-                  className="w-[398px] h-[398px] object-cover"
-                />
+                <img src={`${file}`} alt={`feed-image-${index}`} className="w-[398px] h-[398px] object-cover" />
               </SwiperSlide>
             ))}
           </Swiper>

--- a/src/components/feed/upload/index.tsx
+++ b/src/components/feed/upload/index.tsx
@@ -40,11 +40,6 @@ export default function UploadPage() {
       // url 주소 추가
       const baseAddrss = process.env.NEXT_PUBLIC_S3_BUCKET_URL;
       const fullUrls = uploadedUrls.map((url) => `${baseAddrss}${url}`);
-      console.log(fullUrls);
-      // const fullUrls = [
-      //   "https://fastly.picsum.photos/id/861/400/400.jpg?hmac=Bt3C22W8d4rkkTYLllIRhZyKnD8LLvwgzUmqhGjzKsI",
-      //   "https://fastly.picsum.photos/id/443/500/500.jpg?hmac=k2eq9Aa8gmKfA9nN2fx1CVVqAIhaCzUWfuLT8TaOTtM",
-      // ];
 
       await registerFeed({
         performId: "PF254874",
@@ -54,6 +49,9 @@ export default function UploadPage() {
         fileUrls: fullUrls,
       });
       console.log("등록 성공");
+      alert("등록 성공");
+      useUploadTextStore.getState().reset();
+      handleGoBack();
     } catch (err) {
       console.error("업로드 실패", err);
     }

--- a/src/hooks/feed/use-image-upload.ts
+++ b/src/hooks/feed/use-image-upload.ts
@@ -57,7 +57,7 @@ const useImageUpload = (): UseImageUploadReturn => {
         }
 
         // 2. Presigned URL로 파일 업로드
-        await axios.put(presignedUrl, file.name, {
+        await axios.put(presignedUrl, file, {
           headers: {
             "Content-Type": file.type,
           },

--- a/src/stores/useUploadTextStore.ts
+++ b/src/stores/useUploadTextStore.ts
@@ -13,6 +13,7 @@ interface UploadTextState {
   setHashTags: (newHashtags: string[]) => void;
   setFileUrls: (newFileUrls: string[]) => void;
   setPhotos: (updateFn: (prevPhotos: File[]) => File[]) => void;
+  reset: () => void;
 }
 
 const useUploadTextStore = create<UploadTextState>((set) => ({
@@ -28,6 +29,7 @@ const useUploadTextStore = create<UploadTextState>((set) => ({
   setHashTags: (newHashTags) => set({ hashTags: newHashTags }),
   setFileUrls: (newFileUrls) => set({ fileUrls: newFileUrls }),
   setPhotos: (updateFn) => set((state) => ({ photos: updateFn(state.photos) })),
+  reset: () => set({ performId: "", content: "", category: "", hashTags: [], fileUrls: [], photos: [] }),
 }));
 
 export default useUploadTextStore;


### PR DESCRIPTION
## 📝 요약(Summary)
### 이미지 여러 장 업로드 시 이미지 보이도록 변경
- 원인: 기존 이미지 저장 로직을 개선해 저장 경로 앞에 S3 버킷 주소를 붙여 전체 url이 저장되도록 변경했으나, 이미지 출력 시 추가되는 S3 버킷 주소를 삭제하지 않음
- 해결: 이미지 출력 시에 추가되던 S3 버킷 주소를 삭제하여 여러 장 업로드 시에도 정상적으로 보이도록 수정했습니다.
> 기존 file path: `/(prefix)/(file_name)`, 이미지 src:  `${process.env.NEXT_PUBLIC_S3_BUCKET_URL}{file_path}`
> 변경 file path: `${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/(prefix)/(file_name)}`, 이미지 src: `${file_path}`

### 피드 업로드 성공 시 알람과 함께 feed 페이지로 이동
- 업로드 성공 시 업로드 성공 알람과 함께 feed 페이지로 이동합니다.
- 업로드 성공 후 feed 상태를 초기화하여 이전에 입력한 데이터가 남지 않도록 변경했습니다.

<br/>

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br/>

## 📸스크린샷 (선택)
![image](https://velog.velcdn.com/images/22gyoung/post/d834270f-1e46-485a-afd9-ce6e88011413/image.gif)
<br/>

## 💬 공유사항 to 리뷰어

피드 업로드 시 필요한 공연 관련 정보는 performance_id 뿐인데, add_info에 들어가는 정보 카드에는 해당 공연에 대한 정보가 전부 필요해요. 카드를 불러오기 위해서는 어떤 방법이 제일 좋을까요? 
1. localstorage에 저장한다
2. query로 가져온다
3. 전역 상태에 저장해 가져온다 