### PR TITLE
🐛 Fix: 위시(좋아요) 버그 수정, optimistic update 적용

### DIFF
--- a/src/apis/wishlist-api.ts
+++ b/src/apis/wishlist-api.ts
@@ -51,7 +51,7 @@ export const postAddWishlist = async (performId: string) => {
  * @param performId 공연 ID
  * @returns 서버의 위시리스트 삭제에 따른 응답
  */
-export const removeFromWishlist = async (performId: string) => {
+export const deleteFromWishlist = async (performId: string) => {
   try {
     const response = await apiClient.delete(ENDPOINTS.WISHLIST.DELETE(performId));
     return response.data.result;

--- a/src/app/(main)/performance/[performanceId]/_components/index.tsx
+++ b/src/app/(main)/performance/[performanceId]/_components/index.tsx
@@ -15,7 +15,6 @@ export default function PerformanceDetail() {
   const { data, isLoading, isError } = usePerformanceDetailAll(performanceId);
 
   const facilityId = data?.facilityId;
-  console.log(facilityId);
   const {
     data: facilityInfo,
     isLoading: isFacilityLoading,

--- a/src/app/(main)/performance/[performanceId]/_components/performance-header.tsx
+++ b/src/app/(main)/performance/[performanceId]/_components/performance-header.tsx
@@ -6,9 +6,8 @@ import Chip from "@/components/commons/chip";
 import Gap from "@/components/commons/gap";
 import Icon from "@/components/commons/icons";
 import { SectionLayout } from "@/components/layout";
-import { useAddWishlistMutation, useRemoveWishlistMutation } from "@/hooks/wishlist/use-wishlist-query";
+import { useToggleWishlistMutation } from "@/hooks/wishlist/use-wishlist-query";
 import Link from "next/link";
-import { useState } from "react";
 
 interface Performance {
   genre: string;
@@ -23,37 +22,14 @@ interface Performance {
 }
 
 export default function PerformanceDetailHeader({ performance }: { performance: Performance }) {
-  const {
-    genre,
-    name,
-    location,
-    dateStart,
-    dateEnd,
-    likeCounts,
-    performanceId,
-    feedCounts,
-    isLiked: initialLiked,
-  } = performance;
+  const { genre, name, location, dateStart, dateEnd, likeCounts, performanceId, feedCounts, isLiked } = performance;
 
-  console.log(initialLiked);
-
-  const addWishlistMutation = useAddWishlistMutation();
-  const removeWishlistMutation = useRemoveWishlistMutation();
-
-  const [wishCount, setWishCount] = useState(likeCounts);
-  const [isLiked, setIsLiked] = useState(initialLiked);
+  const toggleWishlistMutation = useToggleWishlistMutation();
 
   const handleLikeToggle = () => {
-    const mutation = isLiked ? removeWishlistMutation : addWishlistMutation;
-
-    mutation.mutate(performanceId, {
-      onSuccess: () => {
-        setIsLiked((prev) => !prev);
-        setWishCount((prev) => prev + (isLiked ? -1 : 1));
-      },
-      onError: (error) => {
-        console.error(`위시리스트 ${isLiked ? "제거" : "추가"} 실패:`, error);
-      },
+    toggleWishlistMutation.mutate({
+      performanceId,
+      isCurrentlyLiked: performance.isLiked,
     });
   };
 
@@ -86,7 +62,7 @@ export default function PerformanceDetailHeader({ performance }: { performance: 
             {isLiked ? <LikeGradientPressed width={33} height={31} /> : <LikeGradientDefault width={33} height={31} />}
           </Icon>
           <p>
-            위시 <span>{wishCount}</span>
+            위시 <span>{likeCounts}</span>
           </p>
         </div>
         <div className="h-20 w-[1px] bg-gray-300 mx-4" />

--- a/src/hooks/wishlist/use-wishlist-query.ts
+++ b/src/hooks/wishlist/use-wishlist-query.ts
@@ -1,8 +1,8 @@
-import { fetchWishlist, fetchWishlistByGenre, postAddWishlist, removeFromWishlist } from "@/apis/wishlist-api";
+import { deleteFromWishlist, fetchWishlist, fetchWishlistByGenre, postAddWishlist } from "@/apis/wishlist-api";
 import { ClientWishlist } from "@/types/wishlist";
 import { wishlistAdapter } from "@/types/wishlist/adapter/wishlist-adapter";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { WISHLIST_KEYS } from "../queries";
+import { PERFORMANCE_KEYS, WISHLIST_KEYS } from "../queries";
 
 // 전체 위시리스트 데이터 조회
 export const useAllWishlistQuery = (rowStart: string, rowEnd: string) => {
@@ -44,9 +44,81 @@ export const useAddWishlistMutation = () => {
 export const useRemoveWishlistMutation = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (performId: string) => removeFromWishlist(performId),
+    mutationFn: (performId: string) => deleteFromWishlist(performId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: WISHLIST_KEYS.all });
     },
   });
 };
+
+// 공연 정보 '위시' 낙관적 업데이트 쿼리
+export function useToggleWishlistMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (props: { performanceId: string; isCurrentlyLiked: boolean }) => {
+      const { performanceId, isCurrentlyLiked } = props;
+      return isCurrentlyLiked ? deleteFromWishlist(performanceId) : postAddWishlist(performanceId);
+    },
+
+    // 낙관적 업데이트
+    onMutate: async ({ performanceId, isCurrentlyLiked }) => {
+      // 캐시 무효화 취소(or 대기) → 낙관적 업데이트 간 경쟁 방지
+      await queryClient.cancelQueries({ queryKey: [WISHLIST_KEYS.all, performanceId] });
+
+      // 이전 데이터 백업
+      const prevWishlistData = queryClient.getQueryData([WISHLIST_KEYS.all, performanceId]);
+      const prevPerformanceData = queryClient.getQueryData([...PERFORMANCE_KEYS.all, "detail-all", performanceId]);
+
+      // 위시리스트 캐시 수정
+      queryClient.setQueryData([WISHLIST_KEYS.all, performanceId], (oldData: any) => {
+        if (!oldData) return oldData;
+        return {
+          ...oldData,
+          isLiked: !oldData.isLiked,
+          likeCounts: oldData.likeCounts + (oldData.isLiked ? -1 : 1),
+        };
+      });
+
+      // 공연 상세 정보 캐시 수정
+      queryClient.setQueryData([...PERFORMANCE_KEYS.all, "detail-all", performanceId], (oldData: any) => {
+        if (!oldData) return oldData;
+        return {
+          ...oldData,
+          isLiked: !isCurrentlyLiked,
+          likeCounts: oldData.likeCounts + (isCurrentlyLiked ? -1 : 1),
+        };
+      });
+
+      return { prevWishlistData, prevPerformanceData };
+    },
+
+    // 에러시 이전 데이터로 롤백
+    onError: (error, props, context) => {
+      // 위시리스트 데이터 롤백
+      if (context?.prevWishlistData) {
+        queryClient.setQueryData([WISHLIST_KEYS.all, props.performanceId], context.prevWishlistData);
+      }
+
+      // 공연 상세 정보 데이터 롤백
+      if (context?.prevPerformanceData) {
+        queryClient.setQueryData(
+          [...PERFORMANCE_KEYS.all, "detail-all", props.performanceId],
+          context.prevPerformanceData,
+        );
+      }
+    },
+
+    // 성공/실패 상관없이 최종 무효화를 통해 서버와 동기화
+    onSettled: (data, error, props) => {
+      // 특정 공연의 상세 데이터 쿼리 무효화
+      queryClient.invalidateQueries({ queryKey: [WISHLIST_KEYS.all, props.performanceId] });
+
+      // “전체 위시리스트”도 최신화(wishlist 탭 바로 이동할 경우 대비)
+      queryClient.invalidateQueries({ queryKey: WISHLIST_KEYS.all });
+
+      // 공연 정보 최신화
+      queryClient.invalidateQueries({ queryKey: [...PERFORMANCE_KEYS.all, "detail-all", props.performanceId] });
+    },
+  });
+}


### PR DESCRIPTION
## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
### 문제점1
- 공연 상세 페이지 내 위시(좋아요)를 빠른 속도로 반복하여 누를 경우 UI와 서버간 동기화가 이루어지지 않는 문제
- 해결: optimistic update 적용
 
### 문제점2
- 좋아요를 누른 뒤 뒤로갔다 다시 오면 UI상 좋아요는 해제되어 있으나, 서버에는 위시리스트에 등록되어있는 문제
- 해결: 좋아요 optimistic update 때 공연 정보 데이터도 최신화하여 클라이언트-서버간 데이터 동기화


<br/>

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br/>

## 📸스크린샷 (선택)

<br/>

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

- 새로 업데이트한 optimistic update부분의 컴포넌트의 경우 상태 관리는 hook 안에서 전담하여 사용하고, UI인 performance-header는 UI만 담당할 수 있도록 관심사 분리하여 구성해보았습니다.