### PR TITLE
✨ Feat: 공연 리스트 Skeleton UI 적용 & Hotfix: 카카오 로그인 오류 해결

### DIFF
--- a/src/app/(main)/_components/banner/index.tsx
+++ b/src/app/(main)/_components/banner/index.tsx
@@ -37,7 +37,6 @@ export default function AdBanner() {
                 loading={index === 0 ? "eager" : "lazy"}
                 quality={85}
               />
-              {index !== 0 && <div className="absolute inset-0 border-gray-200" />}
             </div>
           </SwiperSlide>
         ))}

--- a/src/app/(main)/_components/performance-list.tsx
+++ b/src/app/(main)/_components/performance-list.tsx
@@ -2,6 +2,7 @@
 
 import Location from "@/assets/icons/location.svg";
 import Card from "@/components/card";
+import SkeletonCard from "@/components/card/card.skeleton";
 import Chip from "@/components/commons/chip";
 import LoadingSpinner from "@/components/commons/spinner";
 import Toast from "@/components/commons/toast";
@@ -30,6 +31,7 @@ export default function PerformanceList() {
     hasNextPage,
     isPending,
     isError,
+    isFetching,
     isFetchingNextPage,
   } = usePerformancesInfiniteQuery(selectedTab, genre);
 
@@ -56,7 +58,8 @@ export default function PerformanceList() {
     setSelectedTab(category.id);
   };
 
-  if (isProfileLoading || (isPending && performanceLists.length === 0)) {
+  // 초기 데이터 로드시 로딩 스피너 표시
+  if (isProfileLoading) {
     return (
       <div className="flex justify-center items-center h-[300px]">
         <LoadingSpinner size={40} />
@@ -79,7 +82,10 @@ export default function PerformanceList() {
         activeTab={selectedTab}
       />
 
+      {/* 탭 이동시 CLS 방지 */}
       <SectionLayout className="flex flex-col py-4 gap-3">
+        {performanceLists.length === 0 && isPending && <SkeletonCard count={5} />}
+
         {performanceLists.map((performance) => (
           <Card key={performance.performanceId} href={`/performance/${performance.performanceId}`} className="w-full">
             <Card.Image src={performance.posterUrl} alt={performance.performanceName} size="sm" />
@@ -95,6 +101,10 @@ export default function PerformanceList() {
 
         <div ref={scrollRef} />
 
+        {/* 무한 스크롤 시 스켈레톤 적용 */}
+        {isFetching && performanceLists.length > 0 && <SkeletonCard count={3} />}
+
+        {/* 무한 스크롤 시 로딩 스피너 적용 */}
         {isFetchingNextPage && (
           <div className="flex justify-center items-center p-2">
             <LoadingSpinner size={40} />

--- a/src/app/(main)/_components/performance-list.tsx
+++ b/src/app/(main)/_components/performance-list.tsx
@@ -74,13 +74,7 @@ export default function PerformanceList() {
 
   return (
     <>
-      <Tabs
-        categories={TAB_CATEGORY}
-        gap={12}
-        className="h-11 py-[6px]"
-        onTabClick={handleTabClick}
-        activeTab={selectedTab}
-      />
+      <Tabs categories={TAB_CATEGORY} gap={12} onTabClick={handleTabClick} activeTab={selectedTab} />
 
       {/* 탭 이동시 CLS 방지 */}
       <SectionLayout className="flex flex-col py-4 gap-3">

--- a/src/app/(main)/_components/tabs/index.tsx
+++ b/src/app/(main)/_components/tabs/index.tsx
@@ -48,25 +48,27 @@ export default function Tabs({ categories, gap = 12, onTabClick, activeTab = 0, 
   }, [activeTab]);
 
   return (
-    <Swiper
-      onSwiper={(swiper) => (swiperRef.current = swiper)}
-      slidesPerView="auto"
-      freeMode={true}
-      spaceBetween={gap}
-      slidesOffsetBefore={16}
-      slidesOffsetAfter={16}
-      className={cn("w-full cursor-pointer", className)}
-      preventInteractionOnTransition={true} // 부드러운 전환 유지
-    >
-      {categories.map((category, index) => (
-        <SwiperSlide key={category.id} className="!w-auto">
-          <Chip
-            label={category.name}
-            state={activeTab === category.id ? "selected" : "default"}
-            onClick={() => handleChipClick(category, index)}
-          />
-        </SwiperSlide>
-      ))}
-    </Swiper>
+    <div className="h-11 py-[6px]">
+      <Swiper
+        onSwiper={(swiper) => (swiperRef.current = swiper)}
+        slidesPerView="auto"
+        freeMode={true}
+        spaceBetween={gap}
+        slidesOffsetBefore={16}
+        slidesOffsetAfter={16}
+        className={cn("w-full cursor-pointer", className)}
+        preventInteractionOnTransition={true} // 부드러운 전환 유지
+      >
+        {categories.map((category, index) => (
+          <SwiperSlide key={category.id} className="!w-auto">
+            <Chip
+              label={category.name}
+              state={activeTab === category.id ? "selected" : "default"}
+              onClick={() => handleChipClick(category, index)}
+            />
+          </SwiperSlide>
+        ))}
+      </Swiper>
+    </div>
   );
 }

--- a/src/components/card/card.skeleton.tsx
+++ b/src/components/card/card.skeleton.tsx
@@ -1,0 +1,25 @@
+import cn from "@/lib/tailwind-cn";
+
+interface SkeletonCardProps {
+  count?: number;
+}
+
+export default function SkeletonCard({ count = 1 }: SkeletonCardProps) {
+  return (
+    <>
+      {Array.from({ length: count }).map((_, idx) => (
+        <div key={idx} className={cn("flex p-4 gap-4 mb-3 border border-gray-200 rounded-lg animate-pulse")}>
+          {/* 왼쪽 이미지 */}
+          <div className="flex-shrink-0 w-[88px] h-[88px] bg-gray-100 rounded-lg" />
+
+          {/* 오른쪽 텍스트 */}
+          <div className="flex flex-col justify-center min-w-0 flex-grow">
+            <div className="w-[80px] h-4 bg-gray-100 rounded mb-2" />
+            <div className="w-[120px] h-4 bg-gray-100 rounded mb-2" />
+            <div className="w-full h-4 bg-gray-100 rounded" />
+          </div>
+        </div>
+      ))}
+    </>
+  );
+}

--- a/src/components/card/index.tsx
+++ b/src/components/card/index.tsx
@@ -30,7 +30,7 @@ const SIZE_VARIANTS = {
   sm: {
     width: "w-[88px]",
     height: "h-[88px]",
-    sizes: "(max-width: 768px) 88px",
+    sizes: "88px",
   },
 } as const;
 
@@ -53,7 +53,6 @@ function CardImage({ src, alt, size = "sm", className }: CardImageProps) {
         sizes={sizes}
         className={cn("object-contain transition-opacity duration-500", isLoaded ? "opacity-100" : "opacity-0")}
         onLoad={() => setIsLoaded(true)}
-        priority
       />
     </div>
   );

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,6 +7,7 @@ export function middleware(request: NextRequest) {
 
   const isLoginPage = pathname.startsWith("/login");
   const isOnboardingPage = pathname.startsWith("/onboarding");
+  const isRegistrationFormPage = pathname.startsWith("/registration-form");
 
   // playwright 온보딩 E2E 테스트를 위해 임시 우회(카카오 로그인이 아닌 우회 로그인)
   const e2eBypass = request.cookies.get("e2e-test-skip-auth");
@@ -31,6 +32,10 @@ export function middleware(request: NextRequest) {
   }
   // CASE2. 비로그인 유저
   else {
+    if (isRegistrationFormPage) {
+      return NextResponse.next();
+    }
+
     // 비로그인 유저는 login 외 다른 페이지 접근 불가
     if (!isLoginPage) {
       return NextResponse.redirect(new URL("/login", request.url));


### PR DESCRIPTION
## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
### 1. 최초 공연 장르 탭 이동 스크롤이 맨 위로 움직이는 불편함
> 이전에 홈페이지 접속 이후 최초 탭 이동시 불러온 데이터가 없고, 데이터가 없을 때 따로 UI를 그리지 않았기에 컨텐츠가 있는 맨 위로 스크롤이 이동할 수 밖에 없는 문제가 있었습니다.
 - 스켈레톤 UI를 추가하여 CLS(Cumulative Layout Shift)를 개선하였습니다.
 - 추가로 무한 스크롤 시 로딩 스피너 외에도 스켈레톤 UI를 추가하여, 추가 컨텐츠를 로드중이라는 사실을 더 직관적으로 알 수 있게 변경하였습니다.
- 변경점은 아래 스크린샷을 참고해주세요!


### 2. 그 외
- tab 컴포넌트의 위 아래에 여백이 지정되어 있어야 하는데, 위쪽에 여백이 없고 아래쪽에만 여백이 존재했던 것을 수정하였습니다.

### + hotfix
- 카카오 로그인 이후 registration-form이라는 fallback 페이지에 접근하지 못하는 문제를 해결하였습니다.

<br/>

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br/>

## 📸스크린샷 (선택)
### ※ 최초 탭 이동간 CLS 방지
- (좌) 최초 탭 클릭시 맨 위로 스크롤 이동 현상, (우) 탭 클릭 후에도 변함없는 스크롤 위치
<img src="https://github.com/user-attachments/assets/176bf5ca-14b2-42c4-8162-95674447dbd5" width="280" height="500" />

<img src="https://github.com/user-attachments/assets/83ec51ee-7f15-4816-bab0-5dbed5717d39" width="280" height="500"  />

<br />

- 무한스크롤 중 스켈레톤 UI 추가
<img src="https://github.com/user-attachments/assets/7b22edb9-f390-4c5d-8cf4-b9c989f22e30" width="280" height="500"  />

<br/>

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
